### PR TITLE
fix to handle "#" character in url

### DIFF
--- a/static/player.js
+++ b/static/player.js
@@ -30,7 +30,7 @@ function initPlayer() {
   function setTrack(idx) {
     currentTrackIdx = idx;
     const trackEl = trackEls[idx];
-    audio.src = trackEl.dataset.url;
+    audio.src = trackEl.dataset.url.replace(/#/g, "%23");
     titleEl.innerText = trackEl.dataset.title;
 
     if (idx == 0) {


### PR DESCRIPTION
the player doesn't work as expected on URL having a "#". Audio look the the left part of the first "#" character, then
Uncaught (in promise) DOMException: The media resource indicated by the src attribute or assigned media provider object was not suitable. 

Fix is to fix this issue. There is surely a better way to do it